### PR TITLE
Update package.json to work with new library versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,12 +9,11 @@
 // https://stackabuse.com/how-to-create-c-cpp-addons-in-node/
 
 
-const ref       = require('ref');
+const ref       = require('ref-napi');
 //const CString   = ref.types.CString;
-const Struct    = require('ref-struct')
+const Struct    = require('ref-struct-di')(ref);
 //const ArrayType = require('ref-array');
-const ffi       = require('ffi');
-
+const ffi       = require('ffi-napi');
 
 /**
  * @mainpage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libxdo",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "fake keyboard/mouse input, window management, and more using X11’s XTEST extension and other Xlib functions",
   "main": "index.js",
   "scripts": {
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/HeinrichAD/libxdo#readme",
   "dependencies": {
-    "ffi": "^2.2.0",
-    "ref": "^1.3.5",
-    "ref-struct": "^1.1.0"
+    "ffi-napi": "^4.0.3",
+    "ref-napi": "^3.0.3",
+    "ref-struct-di": "^1.1.1"
   }
 }


### PR DESCRIPTION
Given that `ffi` has been failing to install on node >= 14 and that there is a set of new libraries that fix this (and seem to be a bit more updated), this change should be enough to get things working again. I did my best to follow the structure and style of the existing code, so the only changes are the library references.

I've tested it with Node 17.0.1 (using `example.js`).

I hope this can be merge (and tagged! 🔖 ) so I can use this package properly :)

Let me know if there's any issue! Thank you